### PR TITLE
Docker file for Macchina.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker-compose build
+  - docker-compose up -d
+  - docker-compose ps
+  - docker inspect macchina.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcc:5.4
+
+LABEL maintainer="Günter Obiltschnig"
+
+RUN git clone --branch master https://github.com/macchina-io/macchina.io.git /opt/macchina.io \
+    && make -s -j4 -C /opt/macchina.io DEFAULT_TARGET=shared_release
+
+ENV LD_LIBRARY_PATH /opt/macchina.io/platform/lib/Linux/x86_64
+
+CMD ["/opt/macchina.io/server/bin/Linux/x86_64/macchina"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# meta-docker
-Docker image script for macchina.io
+[![Build Status](https://travis-ci.org/macchina-io/meta-docker.svg?branch=master)](https://travis-ci.org/macchina-io/meta-docker)
+# Macchina.io Meta Docker
+
+## Docker image script for [macchina.io](https://github.com/macchina-io/macchina.io)
+
+You can use this image directly in your project or with the macchina.io project.
+
+The image is uploaded to Dockerhub: [macchinaio/macchina.io](https://hub.docker.com/r/macchinaio/macchina.io/)
+
+## Build
+
+You can also build the image locally:
+
+    $ docker-compose build
+
+or directly by docker:
+
+    $ docker build . -t macchinaio/macchina.io
+
+## Run
+
+To start a container locally, you can execute:
+
+    $ docker-compose up -d
+
+or directly by docker:
+
+    $ docker run -t -d --name macchina.io -p 22080:22080 macchina/macchina.io
+
+Both commands bind port 22080 from docker container to port 22080 on host.
+
+## Status
+
+To get current container status, you can execute:
+
+    $ docker-compose ps
+
+or directly by docker:
+
+    $ docker ps
+
+Both commands will show macchina.io container state.
+
+## License
+The [LICENSE](LICENSE) is under Apache License Version 2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  macchina.io:
+    build: .
+    image: macchinaio/macchina.io
+    container_name: macchina.io
+    ports:
+      - 22080:22080


### PR DESCRIPTION
Hi!

This PR brings some new files:

- Dockerfile that checkout macchina.io on master branch and by default, start macchina service.
- Docker compose file that publish port 22080
- Travis file to build the image

I updated readme file to explain how to build and run the docker image.

I strongly recommend to create a profile at hub.docker.com, my suggestion is macchinaio (only word characters are accepted) and push this image as macchina.io.

Regards.